### PR TITLE
[🍒][PLUGIN-1783] Adding Retry with dev.failsafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <apache.olingo.v2>2.0.0</apache.olingo.v2>
     <wiremock.version>2.27.2</wiremock.version>
     <hydrator.version>2.7.0</hydrator.version>
+    <failsafe.version>3.3.2</failsafe.version>
     <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -61,7 +62,11 @@
   </repositories>
 
   <dependencies>
-
+    <dependency>
+      <groupId>dev.failsafe</groupId>
+      <artifactId>failsafe</artifactId>
+      <version>${failsafe.version}</version>
+    </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-api</artifactId>
@@ -365,12 +370,6 @@
       <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.rholder</groupId>
-      <artifactId>guava-retrying</artifactId>
-      <version>2.0.0</version>
-    </dependency>
-
  </dependencies>
 
   <build>

--- a/src/main/java/io/cdap/plugin/successfactors/connector/SuccessFactorsConnector.java
+++ b/src/main/java/io/cdap/plugin/successfactors/connector/SuccessFactorsConnector.java
@@ -151,7 +151,7 @@ public class SuccessFactorsConnector implements DirectConnector {
     URL dataURL = HttpUrl.parse(config.getBaseURL()).newBuilder().build().url();
     SuccessFactorsTransporter successFactorsHttpClient = new SuccessFactorsTransporter(config);
     SuccessFactorsResponseContainer responseContainer = successFactorsHttpClient.callSuccessFactorsEntity
-      (dataURL, MediaType.APPLICATION_JSON, METADATA);
+      (dataURL, MediaType.APPLICATION_JSON);
     try (InputStream inputStream = responseContainer.getResponseStream()) {
       BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
       String result = reader.lines().collect(Collectors.joining(""));
@@ -225,7 +225,11 @@ public class SuccessFactorsConnector implements DirectConnector {
       addQueryParameter(TOP_OPTION, String.valueOf(top)).addQueryParameter(SELECT_OPTION, selectFields.toString())
       .build().url();
     SuccessFactorsTransporter successFactorsHttpClient = new SuccessFactorsTransporter(config);
-    SuccessFactorsResponseContainer responseContainer = successFactorsHttpClient.callSuccessFactorsWithRetry(dataURL);
+    SuccessFactorsResponseContainer responseContainer =
+      successFactorsHttpClient.callSuccessFactorsWithRetry(
+        dataURL, MediaType.APPLICATION_JSON, SuccessFactorsPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
+        SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS,
+        SuccessFactorsPluginConfig.DEFAULT_RETRY_MULTIPLIER, SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_COUNT);
 
     ExceptionParser.checkAndThrowException("", responseContainer);
     return responseContainer.getResponseStream();
@@ -255,7 +259,7 @@ public class SuccessFactorsConnector implements DirectConnector {
       .addPathSegment(METADATACALL).build().url();
     SuccessFactorsTransporter successFactorsHttpClient = new SuccessFactorsTransporter(config);
     SuccessFactorsResponseContainer responseContainer = successFactorsHttpClient
-      .callSuccessFactorsEntity(metadataURL, MediaType.APPLICATION_XML, METADATA);
+      .callSuccessFactorsEntity(metadataURL, MediaType.APPLICATION_XML);
     return responseContainer.getResponseStream();
     }
   }

--- a/src/main/java/io/cdap/plugin/successfactors/connector/SuccessFactorsConnectorConfig.java
+++ b/src/main/java/io/cdap/plugin/successfactors/connector/SuccessFactorsConnectorConfig.java
@@ -20,7 +20,6 @@ import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
-import io.cdap.plugin.successfactors.common.exception.SuccessFactorsServiceException;
 import io.cdap.plugin.successfactors.common.exception.TransportException;
 import io.cdap.plugin.successfactors.common.util.ResourceConstants;
 import io.cdap.plugin.successfactors.common.util.SuccessFactorsUtil;
@@ -153,7 +152,7 @@ public class SuccessFactorsConnectorConfig extends PluginConfig {
     SuccessFactorsResponseContainer responseContainer = null;
     try {
       responseContainer =
-        successFactorsHttpClient.callSuccessFactorsEntity(testerURL, MediaType.APPLICATION_JSON, TEST);
+        successFactorsHttpClient.callSuccessFactorsEntity(testerURL, MediaType.APPLICATION_JSON);
     } catch (TransportException e) {
       LOG.error("Unable to fetch the response", e);
       collector.addFailure("Unable to call SuccessFactorsEntity",

--- a/src/main/java/io/cdap/plugin/successfactors/source/service/SuccessFactorsService.java
+++ b/src/main/java/io/cdap/plugin/successfactors/source/service/SuccessFactorsService.java
@@ -97,7 +97,7 @@ public class SuccessFactorsService {
   public void checkSuccessFactorsURL() throws TransportException, SuccessFactorsServiceException {
 
     SuccessFactorsResponseContainer responseContainer =
-      successFactorsHttpClient.callSuccessFactorsEntity(urlContainer.getTesterURL(), MediaType.APPLICATION_JSON, TEST);
+      successFactorsHttpClient.callSuccessFactorsEntity(urlContainer.getTesterURL(), MediaType.APPLICATION_JSON);
 
     ExceptionParser.checkAndThrowException(ResourceConstants.ERR_FAILED_ENTITY_VALIDATION.getMsgForKey(),
                                            responseContainer);
@@ -163,7 +163,9 @@ public class SuccessFactorsService {
    */
   private InputStream callEntityMetadata() throws TransportException {
     SuccessFactorsResponseContainer responseContainer = successFactorsHttpClient
-      .callSuccessFactorsEntity(urlContainer.getMetadataURL(), MediaType.APPLICATION_XML, METADATA);
+      .callSuccessFactorsWithRetry(urlContainer.getMetadataURL(), MediaType.APPLICATION_XML, pluginConfig
+        .getInitialRetryDuration(), pluginConfig.getMaxRetryDuration(), pluginConfig.getRetryMultiplier(),
+                                   pluginConfig.getMaxRetryCount());
     return responseContainer.getResponseStream();
   }
 
@@ -320,7 +322,10 @@ public class SuccessFactorsService {
     } else {
       dataURL = urlContainer.getDataFetchURL(skip, top);
     }
-    SuccessFactorsResponseContainer responseContainer = successFactorsHttpClient.callSuccessFactorsWithRetry(dataURL);
+    SuccessFactorsResponseContainer responseContainer =
+      successFactorsHttpClient.callSuccessFactorsWithRetry(
+        dataURL, MediaType.APPLICATION_JSON, pluginConfig.getInitialRetryDuration(), pluginConfig.getMaxRetryDuration(),
+        pluginConfig.getRetryMultiplier(), pluginConfig.getMaxRetryCount());
 
     ExceptionParser.checkAndThrowException("", responseContainer);
     return responseContainer.getResponseStream();
@@ -337,7 +342,7 @@ public class SuccessFactorsService {
 
   /**
    * Filter the data stream after removing the expanded entity data.
-   * 
+   *
    * Data stream after conversion to JSON has the following format:
    * "d": {
    *         "results": [

--- a/src/test/java/io/cdap/plugin/successfactors/connector/SuccessFactorsConnectorTest.java
+++ b/src/test/java/io/cdap/plugin/successfactors/connector/SuccessFactorsConnectorTest.java
@@ -89,7 +89,7 @@ public class SuccessFactorsConnectorTest {
     new Expectations(SuccessFactorsUrlContainer.class, SuccessFactorsTransporter.class,
                      SuccessFactorsSchemaGenerator.class) {
       {
-        successFactorsTransporter.callSuccessFactorsEntity(null, anyString, anyString);
+        successFactorsTransporter.callSuccessFactorsEntity(null, anyString);
         result = getSuccessfulResponseContainer();
         minTimes = 1;
       }
@@ -105,7 +105,7 @@ public class SuccessFactorsConnectorTest {
     new Expectations(SuccessFactorsUrlContainer.class, SuccessFactorsTransporter.class,
                      SuccessFactorsSchemaGenerator.class) {
       {
-        successFactorsTransporter.callSuccessFactorsEntity(null, anyString, anyString);
+        successFactorsTransporter.callSuccessFactorsEntity(null, anyString);
         result = getUnauthorisedResponseContainer();
         minTimes = 1;
       }
@@ -120,7 +120,7 @@ public class SuccessFactorsConnectorTest {
     new Expectations(SuccessFactorsUrlContainer.class, SuccessFactorsTransporter.class,
                      SuccessFactorsSchemaGenerator.class) {
       {
-        successFactorsTransporter.callSuccessFactorsEntity(null, anyString, anyString);
+        successFactorsTransporter.callSuccessFactorsEntity(null, anyString);
         result = getNotFoundResponseContainer();
         minTimes = 1;
       }
@@ -151,7 +151,7 @@ public class SuccessFactorsConnectorTest {
     MockFailureCollector collector = new MockFailureCollector();
     new Expectations(SuccessFactorsTransporter.class) {
       {
-        successFactorsTransporter.callSuccessFactorsEntity(null, anyString, anyString);
+        successFactorsTransporter.callSuccessFactorsEntity(null, anyString);
         result = getSuccessfulResponseContainer();
         minTimes = 1;
 
@@ -190,7 +190,7 @@ public class SuccessFactorsConnectorTest {
         result = getPluginSchema();
         minTimes = 1;
 
-        successFactorsTransporter.callSuccessFactorsEntity(null, anyString, anyString);
+        successFactorsTransporter.callSuccessFactorsEntity(null, anyString);
         result = getResponseContainer();
         minTimes = 1;
       }
@@ -231,7 +231,7 @@ public class SuccessFactorsConnectorTest {
         result = entities;
         minTimes = 1;
 
-        successFactorsTransporter.callSuccessFactorsEntity(null, anyString, anyString);
+        successFactorsTransporter.callSuccessFactorsEntity(null, anyString);
         result = getResponseContainer();
         minTimes = 1;
       }
@@ -258,7 +258,7 @@ public class SuccessFactorsConnectorTest {
     ConnectorContext context = new MockConnectorContext(new MockConnectorConfigurer());
     new Expectations(SuccessFactorsTransporter.class, SuccessFactorsTransporter.class, SuccessFactorsConnector.class) {
       {
-        successFactorsTransporter.callSuccessFactorsEntity(null, anyString, anyString);
+        successFactorsTransporter.callSuccessFactorsEntity(null, anyString);
         result = getResponseContainer();
         minTimes = 1;
       }

--- a/src/test/java/io/cdap/plugin/successfactors/source/SuccessFactorsSourceTest.java
+++ b/src/test/java/io/cdap/plugin/successfactors/source/SuccessFactorsSourceTest.java
@@ -69,6 +69,7 @@ public class SuccessFactorsSourceTest {
   private EntityProvider entityProvider;
   private SuccessFactorsUrlContainer successFactorsUrlContainer;
   private SuccessFactorsSchemaGenerator successFactorsSchemaGenerator;
+  private SuccessFactorsTransporter successFactorsHttpClient;
 
 
   @Before
@@ -163,6 +164,7 @@ public class SuccessFactorsSourceTest {
     successFactorsTransporter = new SuccessFactorsTransporter(pluginConfig.getConnection());
     successFactorsUrlContainer = new SuccessFactorsUrlContainer(pluginConfig);
     successFactorsSchemaGenerator = new SuccessFactorsSchemaGenerator(new SuccessFactorsEntityProvider(edm));
+    successFactorsHttpClient = new  SuccessFactorsTransporter(pluginConfig.getConnection());
 
     new Expectations(SuccessFactorsUrlContainer.class, SuccessFactorsTransporter.class,
                      SuccessFactorsSchemaGenerator.class) {
@@ -175,7 +177,11 @@ public class SuccessFactorsSourceTest {
         result = getUrl();
         minTimes = 1;
 
-        successFactorsTransporter.callSuccessFactorsEntity(null, anyString, anyString);
+        successFactorsHttpClient.callSuccessFactorsWithRetry(null, anyString, anyInt, anyInt, anyInt, anyInt);
+        result = getResponseContainer();
+        minTimes = 1;
+
+        successFactorsTransporter.callSuccessFactorsEntity(null, anyString);
         result = getResponseContainer();
         minTimes = 1;
 

--- a/src/test/java/io/cdap/plugin/successfactors/source/config/SuccessFactorsPluginConfigTest.java
+++ b/src/test/java/io/cdap/plugin/successfactors/source/config/SuccessFactorsPluginConfigTest.java
@@ -174,4 +174,102 @@ public class SuccessFactorsPluginConfigTest {
     Assert.assertEquals("Entity name not trimmed", "entity-name", pluginConfig.getEntityName());
     Assert.assertEquals("Select option not trimmed", "col1,col2,parent/col1,col3", pluginConfig.getSelectOption());
   }
+
+  @Test
+  public void testValidateRetryConfigurationWithDefaultValues() {
+    SuccessFactorsPluginConfig pluginConfig = pluginConfigBuilder
+      .setInitialRetryDuration(SuccessFactorsPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS)
+      .setMaxRetryDuration(SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS)
+      .setMaxRetryCount(SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_COUNT)
+      .setRetryMultiplier(SuccessFactorsPluginConfig.DEFAULT_RETRY_MULTIPLIER)
+      .build();
+    pluginConfig.validateRetryConfiguration(failureCollector);
+    Assert.assertEquals(0, failureCollector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidateRetryConfigurationWithInvalidInitialRetryDuration() {
+    SuccessFactorsPluginConfig pluginConfig = pluginConfigBuilder
+      .setInitialRetryDuration(-1)
+      .setMaxRetryDuration(SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS)
+      .setMaxRetryCount(SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_COUNT)
+      .setRetryMultiplier(SuccessFactorsPluginConfig.DEFAULT_RETRY_MULTIPLIER)
+      .build();
+    pluginConfig.validateRetryConfiguration(failureCollector);
+    Assert.assertEquals(1, failureCollector.getValidationFailures().size());
+    Assert.assertEquals("Initial retry duration must be greater than 0.",
+                        failureCollector.getValidationFailures().get(0).getMessage());
+  }
+
+  @Test
+  public void testValidateRetryConfigurationWithInvalidMaxRetryDuration() {
+    SuccessFactorsPluginConfig pluginConfig = pluginConfigBuilder
+      .setInitialRetryDuration(SuccessFactorsPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS)
+      .setMaxRetryDuration(-1)
+      .setMaxRetryCount(SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_COUNT)
+      .setRetryMultiplier(SuccessFactorsPluginConfig.DEFAULT_RETRY_MULTIPLIER)
+      .build();
+    pluginConfig.validateRetryConfiguration(failureCollector);
+    Assert.assertEquals(2, failureCollector.getValidationFailures().size());
+    Assert.assertEquals("Max retry duration must be greater than 0.",
+                        failureCollector.getValidationFailures().get(0).getMessage());
+    Assert.assertEquals("Max retry duration must be greater than initial retry duration.",
+                        failureCollector.getValidationFailures().get(1).getMessage());
+  }
+
+  @Test
+  public void testValidateRetryConfigurationWithInvalidRetryMultiplier() {
+    SuccessFactorsPluginConfig pluginConfig = pluginConfigBuilder
+      .setInitialRetryDuration(SuccessFactorsPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS)
+      .setMaxRetryDuration(SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS)
+      .setMaxRetryCount(SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_COUNT)
+      .setRetryMultiplier(-1)
+      .build();
+    pluginConfig.validateRetryConfiguration(failureCollector);
+    Assert.assertEquals(1, failureCollector.getValidationFailures().size());
+    Assert.assertEquals("Retry multiplier must be strictly greater than 1.",
+                        failureCollector.getValidationFailures().get(0).getMessage());
+  }
+
+  @Test
+  public void testValidateRetryConfigurationWithInvalidRetryMultiplierAndMaxRetryCount() {
+    SuccessFactorsPluginConfig pluginConfig = pluginConfigBuilder
+      .setInitialRetryDuration(SuccessFactorsPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS)
+      .setMaxRetryDuration(SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS)
+      .setMaxRetryCount(1)
+      .setRetryMultiplier(-1)
+      .build();
+    pluginConfig.validateRetryConfiguration(failureCollector);
+    Assert.assertEquals(1, failureCollector.getValidationFailures().size());
+    Assert.assertEquals("Retry multiplier must be strictly greater than 1.",
+                        failureCollector.getValidationFailures().get(0).getMessage());
+  }
+
+  @Test
+  public void testValidateRetryConfigurationWithMultiplierOne() {
+    SuccessFactorsPluginConfig pluginConfig = pluginConfigBuilder
+      .setInitialRetryDuration(SuccessFactorsPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS)
+      .setMaxRetryDuration(SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS)
+      .setMaxRetryCount(SuccessFactorsPluginConfig.DEFAULT_MAX_RETRY_COUNT)
+      .setRetryMultiplier(1)
+      .build();
+    pluginConfig.validateRetryConfiguration(failureCollector);
+    Assert.assertEquals(1, failureCollector.getValidationFailures().size());
+    Assert.assertEquals("Retry multiplier must be strictly greater than 1.",
+                        failureCollector.getValidationFailures().get(0).getMessage());
+  }
+
+  @Test
+  public void testValidateRetryConfigurationWithMaxRetryLessThanInitialRetry() {
+    SuccessFactorsPluginConfig pluginConfig = pluginConfigBuilder
+      .setInitialRetryDuration(20)
+      .setMaxRetryDuration(10)
+      .setMaxRetryCount(1)
+      .setRetryMultiplier(2)
+      .build();
+    pluginConfig.validateRetryConfiguration(failureCollector);
+    Assert.assertEquals(1, failureCollector.getValidationFailures().size());
+    Assert.assertEquals("Max retry duration must be greater than initial retry duration.",
+                        failureCollector.getValidationFailures().get(0).getMessage());
+  }
 }

--- a/src/test/java/io/cdap/plugin/successfactors/source/input/SuccessFactorsInputFormatTest.java
+++ b/src/test/java/io/cdap/plugin/successfactors/source/input/SuccessFactorsInputFormatTest.java
@@ -38,7 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({SuccessFactorsTransporter.class, SuccessFactorsConnectorConfig.class, Gson.class})
+@PrepareForTest({SuccessFactorsConnectorConfig.class, Gson.class})
 public class SuccessFactorsInputFormatTest {
   public static final String SUCCESSFACTORS_PLUGIN_PROPERTIES = "successFactorsPluginProperties";
   public static final String ENCODED_ENTITY_METADATA_STRING = "encodedMetadataString";
@@ -57,7 +57,8 @@ public class SuccessFactorsInputFormatTest {
                                                               "selectOption",
                                                               "expandOption",
                                                               "additionalQueryParameters",
-                                                              null));
+                                                              null, null,
+                                                              null, null, null));
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/successfactors/source/metadata/SuccessFactorsSchemaGeneratorTest.java
+++ b/src/test/java/io/cdap/plugin/successfactors/source/metadata/SuccessFactorsSchemaGeneratorTest.java
@@ -49,7 +49,8 @@ public class SuccessFactorsSchemaGeneratorTest {
     pluginConfig = new SuccessFactorsPluginConfig("referenceName", "baseUR",
       "entityName", "associateEntityName", "username", "password",
       null, null, null, "filterOption", "selectOption",
-      "expandOption", "additionalQueryParameters", "paginationType");
+      "expandOption", "additionalQueryParameters", "paginationType",
+                                                  null, null, null, null);
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/successfactors/source/transport/SuccessFactorsUrlContainerTest.java
+++ b/src/test/java/io/cdap/plugin/successfactors/source/transport/SuccessFactorsUrlContainerTest.java
@@ -38,7 +38,8 @@ public class SuccessFactorsUrlContainerTest {
                                                               "selectOption",
                                                               "expandOption",
                                                               "",
-                                                              null));
+                                                              null, null,
+                                                              null, null, null));
   }
   @Test
   public void testGetTesterURL() {
@@ -78,7 +79,8 @@ public class SuccessFactorsUrlContainerTest {
                                                               "",
                                                               "",
                                                               "startDate=2023-01-01&endDate=2023-02-02",
-                                                              null));
+                                                              null, null,
+                                                              null, null, null));
     SuccessFactorsUrlContainer urlContainer = new SuccessFactorsUrlContainer(pluginConfig);
     String expectedUrl = "https://successfactors.com/EmpJob?startDate=2023-01-01&endDate=2023-02-02&%24top=1";
     URL actualUrl = urlContainer.getTesterURL();

--- a/widgets/SuccessFactors-batchsource.json
+++ b/widgets/SuccessFactors-batchsource.json
@@ -174,6 +174,42 @@
               }
             ]
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Initial Retry Duration (Seconds)",
+          "name": "initialRetryDuration",
+          "widget-attributes": {
+            "default": "2",
+            "minimum": "1"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Max Retry Duration (Seconds)",
+          "name": "maxRetryDuration",
+          "widget-attributes": {
+            "default": "300",
+            "minimum": "1"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Max Retry Count",
+          "name": "maxRetryCount",
+          "widget-attributes": {
+            "default": "3",
+            "minimum": "1"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Retry Multiplier",
+          "name": "retryMultiplier",
+          "widget-attributes": {
+            "default": "2",
+            "placeholder": "The multiplier to use on retry attempts."
+          }
         }
       ]
     }


### PR DESCRIPTION
[Cherrypick]
Commit : 40c9834ae8f5437aa669a03d89133d74b1237e54
PR: https://github.com/data-integrations/successfactors-plugins/pull/35

---

## Adding Retry with dev.failsafe

Jira : [PLUGIN-1783](https://cdap.atlassian.net/browse/PLUGIN-1783)

### Description

Adding retry on calls to the service, and adding new (hidden) ui fields to let user configure the retry mechanism.

### UI Field

- Modified `SuccessFactors-batchsource.json`
  - Adding hidden fields to let user configure the retry mechanism.
     - retryMultiplier
     - maxRetryCount
     - maxRetryDuration
     - initialRetryDuration

### Docs

- No Changes made to docs.
- Fields are hidden.

### Code change

- Modified `SuccessFactorsConnector.java`
- Modified `SuccessFactorsPluginConfig.java`
- Modified `SuccessFactorsService.java`
- Modified `SuccessFactorsTransporter.java`

### Unit Tests

- Modified `SuccessFactorsPluginConfigTest.java`
- Modified `SuccessFactorsInputFormatTest.java`
- Modified `SuccessFactorsSchemaGeneratorTest.java`
- Modified `SuccessFactorsUrlContainerTest.java`

![image](https://github.com/data-integrations/successfactors-plugins/assets/122770897/d0f37aaa-2dd4-4ba3-a3b8-2a052e437b87)
![image](https://github.com/data-integrations/successfactors-plugins/assets/122770897/3ad0275b-9ccf-42a8-a796-302c8d07f094)




[PLUGIN-1783]: https://cdap.atlassian.net/browse/PLUGIN-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ